### PR TITLE
A DRYer way of building the flags passed into security find-generic-p…

### DIFF
--- a/keyper/__init__.py
+++ b/keyper/__init__.py
@@ -30,7 +30,7 @@ if StrictVersion(platform.mac_ver()[0]) < StrictVersion("10.13.0"):
     raise Exception("This tool is only supported on macOS 10.13.0 or higher")
 
 
-class Certificate():
+class Certificate:
     """Represents a p12 certificate."""
 
     def __init__(self, path, *, password=None):
@@ -120,7 +120,7 @@ class Certificate():
         return private_key_name
 
 
-class Keychain():
+class Keychain:
     """Represents an actual keychain in the system."""
 
     def __init__(self, path: str, password: str, *, is_temporary: bool = False):
@@ -416,7 +416,7 @@ class Keychain():
             raise
 
 
-class TemporaryKeychain():
+class TemporaryKeychain:
     """Context object for working with a temporary keychain."""
 
     def __init__(self):
@@ -454,29 +454,20 @@ def get_password(*, label: str = None, account: str = None, creator: str = None,
 
     command = 'security find-generic-password'
 
-    if label is not None:
-        command += f' -l {shlex.quote(label)}'
+    flags = {
+        "-l": label,
+        "-a": account,
+        "-c": creator,
+        "-C": type_code,
+        "-D": kind,
+        "-G": value,
+        "-j": comment,
+        "-s": service,
+    }
 
-    if account is not None:
-        command += f' -a {shlex.quote(account)}'
-
-    if creator is not None:
-        command += f' -c {shlex.quote(creator)}'
-
-    if type_code is not None:
-        command += f' -C {shlex.quote(type_code)}'
-
-    if kind is not None:
-        command += f' -D {shlex.quote(kind)}'
-
-    if value is not None:
-        command += f' -G {shlex.quote(value)}'
-
-    if comment is not None:
-        command += f' -j {shlex.quote(comment)}'
-
-    if service is not None:
-        command += f' -s {shlex.quote(service)}'
+    for flag, item in flags.items():
+        if item is not None:
+            command += f' {flag} {shlex.quote(item)}'
 
     command += ' -w'
 


### PR DESCRIPTION
A small refactor of the way the `security find-generic-password` command is built, attempting to make this code better adhere to the Don't Repeat Yourself principle from The Pragmatic Programmer.

Pylint report: `Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)`