### PR TITLE
Remove extra indentation from Python README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ A Python 3 library for dealing with the macOS Keychain
 
 ### Examples:
 ```python
-    import keyper
+import keyper
 
-    # Get a password from the keychain
-    password = keyper.get_password(label="my_keychain_password")
+# Get a password from the keychain
+password = keyper.get_password(label="my_keychain_password")
 
-    # Create a temporary keychain and install the certificate:
+# Create a temporary keychain and install the certificate:
 
-    with keyper.TemporaryKeychain() as keychain:
-        certificate = keyper.Certificate("/path/to/cert", password="p4ssw0rd!")
-        keychain.install_cert(certificate)
-        # Use codesign or similar here
+with keyper.TemporaryKeychain() as keychain:
+    certificate = keyper.Certificate("/path/to/cert", password="p4ssw0rd!")
+    keychain.install_cert(certificate)
+    # Use codesign or similar here
 ```
     
 


### PR DESCRIPTION
Remove the extra indent in the Python example from README.
When in a code block, the code does not need to be indented as well.