### PR TITLE
Add python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ def run_setup():
         author_email='dalemy@microsoft.com',
         license='MIT',
         install_requires=[],
+        python_requires='>=3.7',
         classifiers=[
             'Development Status :: 3 - Alpha',
             'Environment :: Console',


### PR DESCRIPTION
This pull request adds `python_requires`  in `setup.py`  to avoid installing the `keyper` in unsupported python versions (lower than 3.7).