### PR TITLE
add py35,py36 support

### DIFF
--- a/keyper/__init__.py
+++ b/keyper/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: future_fstrings -*-
 
 """A utility for dealing with the macOS keychain."""
 
@@ -7,11 +8,16 @@ import logging
 import os
 import platform
 import re
-import secrets
 import shlex
 import subprocess
 import tempfile
 import uuid
+try:
+	from secrets import choice
+except ImportError:
+	from random import SystemRandom
+	_sysrand = SystemRandom()
+	choice = _sysrand.choice
 
 __version__ = '0.3'
 
@@ -348,7 +354,7 @@ class Keychain:
 
         keychain_name = str(uuid.uuid4()) + ".keychain"
         keychain_path = os.path.join(tempfile.gettempdir(), keychain_name)
-        keychain_password = ''.join(secrets.choice(_PASSWORD_ALPHABET) for i in range(50))
+        keychain_password = ''.join(choice(_PASSWORD_ALPHABET) for i in range(50))
 
         if os.path.exists(keychain_path):
             raise Exception("Cannot create temporary keychain. Path already exists: " + keychain_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+future-fstrings

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: future_fstrings -*-
 
 """Tests for the package."""
 


### PR DESCRIPTION
`secrets` doesn't have py3.5 support, but it looks like `choice` is the only part of `secrets` that is used. It's pretty trivial to recreate `choice` in the event of an `ImportError` .

However, `future-fstrings` might be a little more risqué, which is required for anything < 3.7 .

I've set up a branch that incorporates these changes + the CI changes proposed in #12 for demonstration purposes only: [azure pipelines build](https://dev.azure.com/shawkinsl/keyper-ci-poc/_build/results?buildId=27&view=logs)

Happy #Hacktoberfest! :)