### PR TITLE
Documentation: Fix example password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ password = keyper.get_password(label="my_keychain_password")
 # Create a temporary keychain and install the certificate:
 
 with keyper.TemporaryKeychain() as keychain:
-    certificate = keyper.Certificate("/path/to/cert", password="p4ssw0rd!")
+    certificate = keyper.Certificate("/path/to/cert", password="password")
     keychain.install_cert(certificate)
     # Use codesign or similar here
 ```


### PR DESCRIPTION
Changing the example password from `Passw0rd!` to `password` makes it clearer that it's just an example and doesn't indicate that the original was a good choice of password.