### PR TITLE
Allow get_password to skip utf-8 conversion

### DIFF
--- a/keyper/keychain.py
+++ b/keyper/keychain.py
@@ -482,7 +482,7 @@ def get_password(
     comment: Optional[str] = None,
     service: Optional[str] = None,
     keychain: Optional["Keychain"] = None,
-    skip_decode: Optional[bool] = None
+    skip_decode: bool = False
 ) -> Optional[str|bytearray]:
     """Read a password from the system keychain for a given item.
 
@@ -497,7 +497,8 @@ def get_password(
     :param str comment: Match on the comment of the password.
     :param str service: Match on the service of the password.
     :param Keychain keychain: If supplied, only search this keychain, otherwise search all.
-    :param bool skip_decode: Indicates to skip trying to interpret the password as a UTF-8 string, instead returning the password as a `bytearray`. Useful for system passwords
+    :param bool skip_decode: Default `False`. Indicates to skip trying to interpret the password as a UTF-8 string,
+                            instead returning the password as a `bytearray`. Useful for system passwords
 
     :returns: The found password as a `utf-8` string, unless `skip_decode` is set to `True`, in which case the password will be returned as a `bytearray`
     :rtype: str|bytearray|None

--- a/keyper/keychain.py
+++ b/keyper/keychain.py
@@ -482,7 +482,8 @@ def get_password(
     comment: Optional[str] = None,
     service: Optional[str] = None,
     keychain: Optional["Keychain"] = None,
-) -> Optional[str]:
+    skip_decode: Optional[bool] = None
+) -> Optional[str|bytearray]:
     """Read a password from the system keychain for a given item.
 
     Any of the supplied arguments can be used to search for the password.
@@ -496,6 +497,10 @@ def get_password(
     :param str comment: Match on the comment of the password.
     :param str service: Match on the service of the password.
     :param Keychain keychain: If supplied, only search this keychain, otherwise search all.
+    :param bool skip_decode: Indicates to skip trying to interpret the password as a UTF-8 string, instead returning the password as a `bytearray`. Useful for system passwords
+
+    :returns: The found password as a `utf-8` string, unless `skip_decode` is set to `True`, in which case the password will be returned as a `bytearray`
+    :rtype: str|bytearray|None
     """
 
     # pylint: disable=too-many-locals
@@ -561,7 +566,9 @@ def get_password(
 
     if complex_pattern_match:
         hex_value = complex_pattern_match.group(1)
-        password = bytes.fromhex(hex_value).decode("utf-8")
+        password = bytes.fromhex(hex_value)
+        if not skip_decode:
+            password = password.decode("utf-8")
 
     elif simple_pattern_match:
         password = simple_pattern_match.group(1)

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -35,6 +35,9 @@ class KeyperKeychainTests(unittest.TestCase):
         result = keyper.get_password(label="baz", account="bar", service="baz", keychain=keychain)
         assert result == "foo"
 
+        result = keyper.get_password(label="baz", account="bar", service="baz", keychain=keychain, skip_decode=True)
+        assert result == bytearray("foo", "utf-8")
+
         keyper.delete_password(label="baz", account="bar", service="baz", keychain=keychain)
 
         result = keyper.get_password(label="baz", account="bar", service="baz", keychain=keychain)


### PR DESCRIPTION
Hi,

I wanted to use this library in my project, but couldn't because of the lack of support for non-utf-8 strings. It seems like Apple will sometimes store service passwords in the keychain and in this case they will sometimes generate random bytes as the password, which cannot be interpreted as utf-8.

Here's the solution I used in my app for now (I added a doc comment that explains the issue a bit more above this line): https://github.com/parawanderer/OpenTagViewer/blob/0c0be1a1540ff25152521d42683ddb09c22387fa/python/airtag_decryptor.py#L51

In short, the solution I used was to run this system command:
```sh
security find-generic-password -l '{label}' -w
```

`-w` returns the string as a hexadecimal-encoded value without attempting to interpret it as a utf-8 string.

At the level of this library, it seems like it would be a valid solution to just skip the decoding to utf-8 step to match this use-case. Hence the MR.

PS: I could not get the unit tests to work in my MacOS VM for some reason.