### PR TITLE
Follow-up on supporting non-utf8 bytes output

### DIFF
--- a/keyper/keychain.py
+++ b/keyper/keychain.py
@@ -482,8 +482,8 @@ def get_password(
     comment: Optional[str] = None,
     service: Optional[str] = None,
     keychain: Optional["Keychain"] = None,
-    skip_decode: bool = False
-) -> Optional[str|bytearray]:
+    as_bytes: bool = False
+) -> Optional[str|bytes]:
     """Read a password from the system keychain for a given item.
 
     Any of the supplied arguments can be used to search for the password.
@@ -497,11 +497,11 @@ def get_password(
     :param str comment: Match on the comment of the password.
     :param str service: Match on the service of the password.
     :param Keychain keychain: If supplied, only search this keychain, otherwise search all.
-    :param bool skip_decode: Default `False`. Indicates to skip trying to interpret the password as a UTF-8 string,
-                            instead returning the password as a `bytearray`. Useful for system passwords
+    :param bool as_bytes: Default `False`. Indicates to skip trying to interpret the password as a UTF-8 string,
+                          instead returning the password as a `bytes`. Useful for system passwords
 
-    :returns: The found password as a `utf-8` string, unless `skip_decode` is set to `True`, in which case the password will be returned as a `bytearray`
-    :rtype: str|bytearray|None
+    :returns: The found password as a `utf-8` string, unless `skip_decode` is set to `True`, in which case the password will be returned as a `bytes`
+    :rtype: str|bytes|None
     """
 
     # pylint: disable=too-many-locals
@@ -568,14 +568,16 @@ def get_password(
     if complex_pattern_match:
         hex_value = complex_pattern_match.group(1)
         password = bytes.fromhex(hex_value)
-        if not skip_decode:
+        if not as_bytes:
             password = password.decode("utf-8")
 
     elif simple_pattern_match:
         password = simple_pattern_match.group(1)
+        if as_bytes:
+            password = password.encode("utf-8")
 
     else:
-        password = ""
+        password = b"" if as_bytes else ""
 
     return password
 

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -36,7 +36,7 @@ class KeyperKeychainTests(unittest.TestCase):
         assert result == "foo"
 
         result = keyper.get_password(label="baz", account="bar", service="baz", keychain=keychain, skip_decode=True)
-        assert result == bytearray("foo", "utf-8")
+        assert result == "foo".encode("utf-8")
 
         keyper.delete_password(label="baz", account="bar", service="baz", keychain=keychain)
 


### PR DESCRIPTION
Hi @dalemyers

So I messed around with it a bit more, and I actually got the tests to run on my VM this time through the VSCode UI, and figured it could make more sense from an API point of view to make the output more standardized (so that when you ask it for bytes it will always give you bytes, not just in a weird conditional way where it could randomly give you a string in some cases). 

I am not sure if there's a comprehensive way to test setting a non-utf8-bytes password using the library, but extending your existing testcase works now. The previous test doesn't work in my previous adaptation, because that password wouldn't get stored as a `0xblah` value:

![image](https://github.com/user-attachments/assets/9a674ab4-cfbd-433d-a9e2-013fecd71bec)


^ Unfortunately I can't reuse the "`BeaconStore`"-labelled password in a dedicated unit test to cover that case from my original use-case to test an "originally-as-bytes" password, as that thing prompts you for 2 manual System Password entries 😞. 


I do apologise for any confusion on the test (I thought there might be some CI step that would run the tests and fail in absence of me managing to run them on my local machine 🙈 😅 )